### PR TITLE
【Fixed】 Issues/#3 (issues/#67 in origin)

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[destroy] #show edit update]
 
   def index
     @agendas = Agenda.all
@@ -18,6 +18,17 @@ class AgendasController < ApplicationController
       redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
+    end
+  end
+  def destroy
+    if @agenda.team.owner_id == current_user.id
+      @agenda.destroy
+      @agenda.team.members.each do |member|
+        AgendaMailer.agenda_mail(member.email, @agenda).deliver
+      end
+      redirect_to dashboard_url, notice: "#{@agenda.title} was successfully deleted"
+    else
+      redirect_to team_url(@agenda.team_id), notice: I18n.t(%(You don't have an authority to delete agendas))
     end
   end
 

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,2 @@
+class AgendaMailer < ApplicationMailer
+end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,2 +1,9 @@
 class AgendaMailer < ApplicationMailer
+  default from: 'from@example.com'
+
+  def agenda_mail(email, agenda)
+    @email = email
+    @agenda = agenda
+    mail to: @email, subject: "Agenda deleted"
+  end
 end

--- a/app/views/agenda_mailer/agenda_mail.html.erb
+++ b/app/views/agenda_mailer/agenda_mail.html.erb
@@ -1,0 +1,3 @@
+<h1>Agenda deleted</h1>
+
+<h4><%= @agenda.title %> was deleted by Team Owner</h4>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -37,6 +37,9 @@
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
+            <% if agenda.team.owner_id == current_user.id %>
+              <%= link_to 'delete', agenda_path(agenda), method: :delete, data: { confirm: 'Are you sure?' },  class: "btn btn-sm btn-danger" %>
+            <% end %>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/spec/mailers/agenda_mailer_spec.rb
+++ b/spec/mailers/agenda_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_mailer_preview.rb
+++ b/spec/mailers/previews/agenda_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda_mailer
+class AgendaMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
#3 
- [x] agendas_controllerにdestroyアクションを追加
- [x] サイドバーにアジェンダの削除ボタンを作成（チームオーナーのみ表示）